### PR TITLE
Potential fix for code scanning alert no. 20: Server-side request forgery

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -31,7 +31,7 @@ public class SSRFTask2 implements AssignmentEndpoint {
   }
 
   protected AttackResult furBall(String url) {
-    if (url.matches("http://ifconfig\\.pro")) {
+    if ("http://ifconfig.pro".equals(url)) {
       String html;
       try (InputStream in = new URL(url).openStream()) {
         html =


### PR DESCRIPTION
Potential fix for [https://github.com/endmasks/WebGoat/security/code-scanning/20](https://github.com/endmasks/WebGoat/security/code-scanning/20)

To fix the SSRF vulnerability, the code should strictly validate the user-provided URL against a whitelist of allowed URLs. The best way is to compare the input string to the exact allowed URL, using string equality rather than a regex match, and ensure no additional path, query, or encoding tricks can bypass the check. Only if the input matches the allowed URL exactly should the request be made. This change should be made in the `furBall` method in `src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java`, specifically replacing the regex match with a strict equality check.

No new imports are needed, as all required classes are already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
